### PR TITLE
Can't subscribe to canonical symbols

### DIFF
--- a/QuantConnect.TemplateBrokerage/TemplateBrokerage.cs
+++ b/QuantConnect.TemplateBrokerage/TemplateBrokerage.cs
@@ -216,7 +216,7 @@ namespace QuantConnect.TemplateBrokerage
 
         private bool CanSubscribe(Symbol symbol)
         {
-            if (symbol.Value.IndexOfInvariant("universe", true) != -1)
+            if (symbol.Value.IndexOfInvariant("universe", true) != -1 || symbol.IsCanonical())
             {
                 return false;
             }


### PR DESCRIPTION
- By default can't subscribe to canonical symbols.

Related https://github.com/QuantConnect/Lean.Brokerages.Samco/issues/18