### PR TITLE
Add generic brokerage regression algorithm

### DIFF
--- a/QuantConnect.TemplateBrokerage.Tests/BrokerageAlgorithmSettings.cs
+++ b/QuantConnect.TemplateBrokerage.Tests/BrokerageAlgorithmSettings.cs
@@ -1,0 +1,259 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using QuantConnect.Data.Market;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Brokerages.Template.Tests
+{
+    public class BrokerageAlgorithmSettings
+    {
+        private string _url;
+        public Symbol OptionContract;
+        public Symbol FutureContract;
+        public Symbol FutureOptionContract;
+        public Symbol IndexOptionContract;
+        public Dictionary<SecurityType, Symbol> SymbolsPerSecurityType;
+        public BrokerageName BrokerageName { get; set; } = BrokerageName.Default;
+        public Resolution Resolution => Resolution.Minute;
+        public int OpenOrdersTimeout => 5;
+        public BaseMarketSymbols MarketSymbols { get; protected set; }
+        public Symbol EquitySymbol => MarketSymbols.EquitySymbol;
+        public Symbol ForexSymbol => MarketSymbols.ForexSymbol;
+        public Symbol CryptoSymbol => MarketSymbols.CryptoSymbol;
+        public Symbol CfdSymbol => MarketSymbols.CfdSymbol;
+        public Symbol CryptoFutureSymbol => MarketSymbols.CryptoFutureSymbol;
+        public Symbol CanonicalOptionSymbol => MarketSymbols.CanonicalOptionSymbol;
+        public Symbol CanonicalIndexOptionSymbol => MarketSymbols.CanonicalIndexOptionSymbol;
+        public Symbol CanonicalFutureSymbol => MarketSymbols.CanonicalFutureSymbol;
+        public Symbol CanonicalFutureOptionSymbol => MarketSymbols.CanonicalFutureOptionSymbol;
+        public Func<OptionFilterUniverse, OptionFilterUniverse> IndexOptionFilter => null;
+        public Func<FutureFilterUniverse, FutureFilterUniverse> FutureFilter => u => u.Expiration(0, 182);
+        public Func<OptionFilterUniverse, OptionFilterUniverse> FutureOptionFilter => u => u.Strikes(-2, +2).Expiration(0, 60);
+        public Func<OptionFilterUniverse, OptionFilterUniverse> OptionFilter => u => u.Strikes(-2, +2).Expiration(0, 60);
+        public Dictionary<OrderType, List<Symbol>> SymbolToTestPerOrderType { get; protected set; }
+        public List<SecurityType> Securities { get; protected set; }
+        public List<OrderType> OrderTypes { get; protected set; }
+        public List<Resolution> Resolutions { get; protected set; }
+        public List<Type> DataTypes { get; protected set; }
+        public List<string> Markets { get; protected set; }
+        public List<Symbol> SecurityTypes { get; protected set; }
+        public List<Symbol> SecurityTypesToAdd { get; protected set; }
+        public Dictionary<SecurityType, List<Resolution>> ResolutionsPerSecurity { get ; protected set; }
+        public Dictionary<SecurityType, List<Type>> DataTypesPerSecurity { get; protected set; }
+
+        public BrokerageAlgorithmSettings(string brokerageSettingsURL)
+        {
+            _url = brokerageSettingsURL;
+            LoadConfigs();
+            SymbolsToAdd();
+        }
+
+        public async void LoadConfigs()
+        {
+            var json = _url.DownloadData();
+            var jObject = JObject.Parse(json);
+            var jsonSecurities = jObject["module-specification"]["download"]["security-types"].ToString();
+            Securities = JsonConvert.DeserializeObject<List<SecurityType>>(jsonSecurities);
+
+            var jsonOrderTypes = jObject["order-types"].ToString();
+            var orderTypes = JsonConvert.DeserializeObject<List<string>>(jsonOrderTypes);
+            ConvertOrderTypes(orderTypes);
+
+            var jsonResolutions = jObject["module-specification"]["download"]["resolutions"].ToString();
+            Resolutions = JsonConvert.DeserializeObject<List<Resolution>>(jsonResolutions);
+            Resolutions = Resolutions.Where(x => x != Resolution.Tick).ToList();
+
+            var jsonDataTypes = jObject["module-specification"]["download"]["data-types"].ToString();
+            var dataTypes = JsonConvert.DeserializeObject<List<string>>(jsonDataTypes);
+            ConvertDataTypes(dataTypes);
+
+            var jsonMarkets = jObject["module-specification"]["download"]["markets"].ToString();
+            Markets = JsonConvert.DeserializeObject<List<string>>(jsonMarkets);
+            ConfigSymbols();
+        }
+
+        public void InitializeSymbols()
+        {
+            SecurityTypes = SecurityTypesToAdd.Select(x =>
+            {
+                switch (x.SecurityType)
+                {
+                    case SecurityType.Future:
+                        return FutureContract;
+                    case SecurityType.Option:
+                        return OptionContract;
+                    case SecurityType.IndexOption:
+                        return IndexOptionContract;
+                    case SecurityType.FutureOption:
+                        return FutureOptionContract;
+                    default:
+                        return x;
+                }
+            }).ToList();
+
+            SymbolToTestPerOrderType = OrderTypes.ToDictionary(x => x, x => SecurityTypes);
+            ResolutionsPerSecurity = Securities.ToDictionary(x => x, x => Resolutions);
+            DataTypesPerSecurity = Securities.ToDictionary(x => x, x => DataTypes);
+        }
+
+        private void ConvertOrderTypes(List<string> orderTypes)
+        {
+            var orderTypesDict = new Dictionary<string, dynamic>();
+            foreach(var orderType in Enum.GetValues(typeof(OrderType)))
+            {
+                orderTypesDict[orderType.ToString()] = orderType;
+            }
+
+            OrderTypes = new List<OrderType>();
+            foreach(var orderType in orderTypes)
+            {
+                if (orderType == "Trailing")
+                {
+                    OrderTypes.Add(OrderType.TrailingStop);
+                }
+                else if (orderType == "Exercise")
+                {
+                    OrderTypes.Add(OrderType.OptionExercise);
+                }
+                else
+                {
+                    OrderTypes.Add(orderTypesDict[orderType.Replace(" ", "").Replace("-", "")]);
+                }
+            }
+        }
+
+        private void ConvertDataTypes(List<string> types)
+        {
+            DataTypes = new List<Type>();
+            foreach(var type in types)
+            {
+                if (type == "Trade")
+                {
+                    DataTypes.Add(typeof(TradeBar));
+                }
+                else if (type == "Quote")
+                {
+                    DataTypes.Add(typeof(QuoteBar));
+                }
+            }
+        }
+
+        private void ConfigSymbols()
+        {
+            MarketSymbols = new BaseMarketSymbols();
+            if (Markets.Contains("USA"))
+            {
+                MarketSymbols = new DefaultMarketSymbols();
+            }
+            else if (Markets.Contains("Kraken"))
+            {
+                MarketSymbols.CryptoSymbol = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Kraken);
+            }
+            else if (Markets.Contains("Binance"))
+            {
+                MarketSymbols.CryptoSymbol = Symbol.Create("BTCUSDT", SecurityType.Crypto, Market.Binance);
+                MarketSymbols.CryptoFutureSymbol = Symbol.Create("BTCUSDT", SecurityType.CryptoFuture, Market.Binance);
+            }
+            else if (Markets.Contains("Bybit"))
+            {
+                MarketSymbols.CryptoSymbol = Symbol.Create("BTCUSDT", SecurityType.Crypto, Market.Bybit);
+                MarketSymbols.CryptoFutureSymbol = Symbol.Create("BTCUSDT", SecurityType.CryptoFuture, Market.Bybit);
+            }
+            else if (Markets.Contains("Oanda"))
+            {
+                MarketSymbols.ForexSymbol = Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda);
+            }
+            else if (Markets.Contains("Bitfinex"))
+            {
+                MarketSymbols.CryptoSymbol = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Bitfinex);
+    }
+            else if (Markets.Contains("Coinbase"))
+            {
+                MarketSymbols.CryptoSymbol = Symbol.Create("BTCUSD", SecurityType.Crypto, Market.Coinbase);
+            }
+        }
+
+        private void SymbolsToAdd()
+        {
+            SecurityTypesToAdd = new List<Symbol>();
+            foreach(var securityType in Securities)
+            {
+                switch (securityType)
+                {
+                    case SecurityType.Equity:
+                        SecurityTypesToAdd.Add(EquitySymbol);
+                        break;
+                    case SecurityType.Option:
+                        SecurityTypesToAdd.Add(CanonicalOptionSymbol);
+                        break;
+                    case SecurityType.Forex:
+                        SecurityTypesToAdd.Add(ForexSymbol);
+                        break;
+                    case SecurityType.Future:
+                        SecurityTypesToAdd.Add(CanonicalFutureSymbol);
+                        break;
+                    case SecurityType.Cfd:
+                        SecurityTypesToAdd.Add(CfdSymbol);
+                        break;
+                    case SecurityType.Crypto:
+                        SecurityTypesToAdd.Add(CryptoSymbol);
+                        break;
+                    case SecurityType.FutureOption:
+                        SecurityTypesToAdd.Add(CanonicalFutureOptionSymbol);
+                        break;
+                    case SecurityType.IndexOption:
+                        SecurityTypesToAdd.Add(CanonicalIndexOptionSymbol);
+                        break;
+                    case SecurityType.CryptoFuture:
+                        SecurityTypesToAdd.Add(CryptoFutureSymbol);
+                        break;
+                }
+            }
+        }
+    }
+
+    public class BaseMarketSymbols
+    {
+        public virtual Symbol EquitySymbol { get; set; }
+        public virtual Symbol ForexSymbol { get; set; }
+        public virtual Symbol CryptoSymbol { get; set; }
+        public virtual Symbol CfdSymbol { get; set; }
+        public virtual Symbol CryptoFutureSymbol { get; set; }
+        public virtual Symbol CanonicalOptionSymbol { get; set; }
+        public virtual Symbol CanonicalIndexOptionSymbol { get; set; }
+        public virtual Symbol CanonicalFutureSymbol { get; set; }
+        public virtual Symbol CanonicalFutureOptionSymbol { get; }
+    }
+
+    public class DefaultMarketSymbols : BaseMarketSymbols
+    {
+        public override Symbol EquitySymbol { get; set; } = Symbol.Create("AAPL", SecurityType.Equity, Market.USA);
+        public override Symbol ForexSymbol { get; set; } = Symbol.Create("EURUSD", SecurityType.Forex, Market.Oanda);
+        public override Symbol CryptoSymbol { get; set; } = Symbol.Create("BTCUSDT", SecurityType.Crypto, Market.Bybit);
+        public override Symbol CfdSymbol { get; set; } = Symbol.Create("XAUUSD", SecurityType.Cfd, Market.Oanda);
+        public override Symbol CryptoFutureSymbol { get; set; } = Symbol.Create("BTCUSDT", SecurityType.CryptoFuture, Market.Bybit);
+        public override Symbol CanonicalOptionSymbol { get; set; } = Symbol.Create("AAPL", SecurityType.Option, Market.USA);
+        public override Symbol CanonicalIndexOptionSymbol { get; set; } = Symbol.Create("SPX", SecurityType.IndexOption, Market.USA);
+        public override Symbol CanonicalFutureSymbol { get; set; } = Symbol.Create("ES", SecurityType.Future, Market.CME);
+        public override Symbol CanonicalFutureOptionSymbol => Symbol.CreateOption(CanonicalFutureSymbol, Market.CME, OptionStyle.American, OptionRight.Put, 1000, new DateTime(2024, 1, 1));
+    }
+}

--- a/QuantConnect.TemplateBrokerage.Tests/BrokerageAlgorithmSettings.cs
+++ b/QuantConnect.TemplateBrokerage.Tests/BrokerageAlgorithmSettings.cs
@@ -24,6 +24,10 @@ using System.Linq;
 
 namespace QuantConnect.Brokerages.Template.Tests
 {
+    /// <summary>
+    /// Class containing the security types, order types, data types and resolutions supported by
+    /// certain brokerage
+    /// </summary>
     public class BrokerageAlgorithmSettings
     {
         private string _url;
@@ -123,7 +127,7 @@ namespace QuantConnect.Brokerages.Template.Tests
         /// <summary>
         /// List of security types allowed by the brokerage
         /// </summary>
-        public List<SecurityType> Securities { get; protected set; }
+        public List<SecurityType> SecurityTypes { get; protected set; }
 
         /// <summary>
         /// List of order types allowed by the brokerage
@@ -151,14 +155,6 @@ namespace QuantConnect.Brokerages.Template.Tests
         public List<Symbol> Symbols { get; protected set; }
 
         /// <summary>
-        /// List of symbols to add in the algorithm
-        /// </summary>
-        /// <remarks>The difference between this property and Symbols is that this list
-        /// contains the canonical symbols for options, futures, future options and index
-        /// options while Symbols contains the contracts</remarks>
-        public List<Symbol> SymbolsToAdd { get; protected set; }
-
-        /// <summary>
         /// Dictionary where each key is a security type and the value associated with it is a list
         /// of resolutions for which a history request will be made at the mentioned security type.
         /// For example, if the key is Forex and the value is a list with Minute, Second and Hour
@@ -176,6 +172,10 @@ namespace QuantConnect.Brokerages.Template.Tests
         /// </summary>
         public Dictionary<SecurityType, List<Type>> DataTypesPerSecurity { get; protected set; }
 
+        /// <summary>
+        /// Initializes an instance of BrokerageAlgorithmSettingsURL class
+        /// </summary>
+        /// <param name="brokerageSettingsURL">URL of the brokerage settings json file</param>
         public BrokerageAlgorithmSettings(string brokerageSettingsURL)
         {
             _url = brokerageSettingsURL;
@@ -192,7 +192,7 @@ namespace QuantConnect.Brokerages.Template.Tests
             var json = _url.DownloadData();
             var jObject = JObject.Parse(json);
             var jsonSecurities = jObject["module-specification"]["download"]["security-types"].ToString();
-            Securities = JsonConvert.DeserializeObject<List<SecurityType>>(jsonSecurities);
+            SecurityTypes = JsonConvert.DeserializeObject<List<SecurityType>>(jsonSecurities);
 
             var jsonOrderTypes = jObject["order-types"].ToString();
             var orderTypes = JsonConvert.DeserializeObject<List<string>>(jsonOrderTypes);
@@ -219,7 +219,7 @@ namespace QuantConnect.Brokerages.Template.Tests
         /// </summary>
         public void InitializeSymbols()
         {
-            Symbols = SymbolsToAdd.Select(x =>
+            Symbols = Symbols.Select(x =>
             {
                 switch (x.SecurityType)
                 {
@@ -243,8 +243,8 @@ namespace QuantConnect.Brokerages.Template.Tests
             // for each resolution, order type and data type.
             // See InteractiveBrokersBrokerageRegressionAlgorithm
             SymbolToTestPerOrderType = OrderTypes.ToDictionary(x => x, x => Symbols);
-            ResolutionsPerSecurity = Securities.ToDictionary(x => x, x => Resolutions);
-            DataTypesPerSecurity = Securities.ToDictionary(x => x, x => DataTypes);
+            ResolutionsPerSecurity = SecurityTypes.ToDictionary(x => x, x => Resolutions);
+            DataTypesPerSecurity = SecurityTypes.ToDictionary(x => x, x => DataTypes);
         }
 
         /// <summary>
@@ -340,37 +340,37 @@ namespace QuantConnect.Brokerages.Template.Tests
         /// </summary>
         private void SelectSymbolsToAdd()
         {
-            SymbolsToAdd = new List<Symbol>();
-            foreach(var securityType in Securities)
+            Symbols = new List<Symbol>();
+            foreach(var securityType in SecurityTypes)
             {
                 switch (securityType)
                 {
                     case SecurityType.Equity:
-                        SymbolsToAdd.Add(EquitySymbol);
+                        Symbols.Add(EquitySymbol);
                         break;
                     case SecurityType.Option:
-                        SymbolsToAdd.Add(CanonicalOptionSymbol);
+                        Symbols.Add(CanonicalOptionSymbol);
                         break;
                     case SecurityType.Forex:
-                        SymbolsToAdd.Add(ForexSymbol);
+                        Symbols.Add(ForexSymbol);
                         break;
                     case SecurityType.Future:
-                        SymbolsToAdd.Add(CanonicalFutureSymbol);
+                        Symbols.Add(CanonicalFutureSymbol);
                         break;
                     case SecurityType.Cfd:
-                        SymbolsToAdd.Add(CfdSymbol);
+                        Symbols.Add(CfdSymbol);
                         break;
                     case SecurityType.Crypto:
-                        SymbolsToAdd.Add(CryptoSymbol);
+                        Symbols.Add(CryptoSymbol);
                         break;
                     case SecurityType.FutureOption:
-                        SymbolsToAdd.Add(CanonicalFutureOptionSymbol);
+                        Symbols.Add(CanonicalFutureOptionSymbol);
                         break;
                     case SecurityType.IndexOption:
-                        SymbolsToAdd.Add(CanonicalIndexOptionSymbol);
+                        Symbols.Add(CanonicalIndexOptionSymbol);
                         break;
                     case SecurityType.CryptoFuture:
-                        SymbolsToAdd.Add(CryptoFutureSymbol);
+                        Symbols.Add(CryptoFutureSymbol);
                         break;
                 }
             }

--- a/QuantConnect.TemplateBrokerage.Tests/BybitBrokerageRegressionAlgorithm.cs
+++ b/QuantConnect.TemplateBrokerage.Tests/BybitBrokerageRegressionAlgorithm.cs
@@ -1,0 +1,23 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+namespace QuantConnect.Brokerages.Template.Tests
+{
+    public class BybitBrokerageRegressionAlgorithm : TemplateFeatureRegressionAlgorithm
+    {
+        public override BrokerageName Brokerage { get; set; } = BrokerageName.Bybit;
+        protected override string BrokerageSettingsURL { get; set; } = "https://raw.githubusercontent.com/QuantConnect/Lean.Brokerages.ByBit/master/bybit.json";
+    }
+}

--- a/QuantConnect.TemplateBrokerage.Tests/InteractiveBrokersBrokerageRegressionAlgorithm.cs
+++ b/QuantConnect.TemplateBrokerage.Tests/InteractiveBrokersBrokerageRegressionAlgorithm.cs
@@ -1,0 +1,40 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Orders;
+using System.Collections.Generic;
+
+namespace QuantConnect.Brokerages.Template.Tests
+{
+    public class InteractiveBrokersBrokerageRegressionAlgorithm : TemplateFeatureRegressionAlgorithm
+    {
+        public override BrokerageName Brokerage { get; set; } = BrokerageName.InteractiveBrokersBrokerage;
+        protected override string BrokerageSettingsURL { get; set; } = "https://raw.githubusercontent.com/QuantConnect/Lean.Brokerages.InteractiveBrokers/master/interactivebrokers.json";
+        protected override decimal GetOrderQuantity(Symbol symbol)
+        {
+            if (symbol.SecurityType == SecurityType.Forex)
+            {
+                return 20000;
+            }
+            return Securities[symbol].SymbolProperties.MinimumOrderSize ?? 1;
+        }
+        protected override void SetupSymbols()
+        {
+            base.SetupSymbols();
+            BrokerageAlgorithmSettings.SymbolToTestPerOrderType[OrderType.MarketOnOpen] = new List<Symbol>() { BrokerageAlgorithmSettings.EquitySymbol, BrokerageAlgorithmSettings.OptionContract };
+            BrokerageAlgorithmSettings.SymbolToTestPerOrderType[OrderType.MarketOnClose] = new List<Symbol>() { BrokerageAlgorithmSettings.EquitySymbol, BrokerageAlgorithmSettings.FutureContract };
+        }
+    }
+}

--- a/QuantConnect.TemplateBrokerage.Tests/TemplateFeatureRegressionAlgorithm.cs
+++ b/QuantConnect.TemplateBrokerage.Tests/TemplateFeatureRegressionAlgorithm.cs
@@ -65,7 +65,7 @@ namespace QuantConnect.Brokerages.Template.Tests
     /// if the order type is StopMarket and the associated symbols associated with
     /// it in the dictionary are AAPL, EURGBP and BTCETH, the algorithm will submit
     /// a stop market order for each of those symbols. It's also worth saying, that
-    /// this method can be overrided in case certain order type does not accept
+    /// this method can be overriden in case certain order type does not accept
     /// all the security types allowed by the brokerage. Finally, this method will
     /// also initialize a dictionary that will count the number of data points
     /// received by each symbol.

--- a/QuantConnect.TemplateBrokerage.Tests/TemplateFeatureRegressionAlgorithm.cs
+++ b/QuantConnect.TemplateBrokerage.Tests/TemplateFeatureRegressionAlgorithm.cs
@@ -1,0 +1,488 @@
+/*
+ * QUANTCONNECT.COM - Democratizing Finance, Empowering Individuals.
+ * Lean Algorithmic Trading Engine v2.0. Copyright 2014 QuantConnect Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+using QuantConnect.Algorithm;
+using QuantConnect.Data;
+using QuantConnect.Data.Market;
+using QuantConnect.Orders;
+using QuantConnect.Securities;
+using QuantConnect.Securities.Future;
+using QuantConnect.Securities.FutureOption;
+using QuantConnect.Securities.IndexOption;
+using QuantConnect.Securities.Option;
+using QuantConnect.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuantConnect.Brokerages.Template.Tests
+{
+    public abstract class TemplateFeatureRegressionAlgorithm: QCAlgorithm
+    {
+        public abstract BrokerageName Brokerage { get; set; }
+        private int _testCaseIndex;
+        private bool _submittedMarketOnCloseToday;
+        private DateTime _last = DateTime.MinValue;
+        private List<OrderType> _orderTypes;
+        private Dictionary<OrderType, Func<Slice, List<OrderTicket>>> _orderTypeMethods;
+        private bool _symbolsHaveBeenSetup;
+        protected BrokerageAlgorithmSettings BrokerageAlgorithmSettings;
+        private Dictionary<Symbol, int> _pointsFoundPerSymbol;
+        protected abstract string BrokerageSettingsURL { get; set; }
+
+        public override void Initialize()
+        {
+            SetStartDate(2024, 07, 20);
+            SetEndDate(2024, 07, 29);
+            SetCash(100000000);
+            SetCash("USDT", 10000);
+
+            BrokerageAlgorithmSettings = new BrokerageAlgorithmSettings(BrokerageSettingsURL);
+            BrokerageAlgorithmSettings.BrokerageName = Brokerage;
+            SetBrokerageModel(BrokerageAlgorithmSettings.BrokerageName);
+            AddSymbols();
+
+            _orderTypeMethods = new()
+            {
+                { OrderType.Market, new Func<Slice, List<OrderTicket>>(slice => ExecuteOrder(OrderType.Market)) },
+                { OrderType.Limit, new Func<Slice, List<OrderTicket>>(slice => ExecuteOrder(OrderType.Limit)) },
+                { OrderType.StopMarket, new Func<Slice, List<OrderTicket>>(slice => ExecuteOrder(OrderType.StopMarket)) },
+                { OrderType.StopLimit, new Func<Slice, List<OrderTicket>>(slice => ExecuteOrder(OrderType.StopLimit)) },
+                { OrderType.MarketOnOpen, new Func<Slice, List<OrderTicket>>(slice => ExecuteMarketOnOpenOrders()) },
+                { OrderType.MarketOnClose, new Func<Slice, List<OrderTicket>>(slice => ExecuteMarketOnCloseOrders()) },
+                { OrderType.OptionExercise, new Func<Slice, List<OrderTicket>>(slice => ExecuteOptionExerciseOrder()) },
+                { OrderType.LimitIfTouched, new Func<Slice, List<OrderTicket>>(slice => ExecuteOrder(OrderType.LimitIfTouched)) },
+                { OrderType.ComboMarket, new Func<Slice, List<OrderTicket>>(slice => ExecuteComboOrder(slice, OrderType.ComboMarket)) },
+                { OrderType.ComboLimit, new Func<Slice, List<OrderTicket>>(slice => ExecuteComboOrder(slice, OrderType.ComboLimit)) },
+                { OrderType.ComboLegLimit, new Func<Slice, List<OrderTicket>>(slice => ExecuteComboOrder(slice, OrderType.ComboLegLimit)) },
+                { OrderType.TrailingStop, new Func<Slice, List<OrderTicket>>(slice => ExecuteOrder(OrderType.TrailingStop)) },
+            };
+        }
+
+        protected virtual void AddSymbols()
+        {
+            foreach(var symbol in BrokerageAlgorithmSettings.SecurityTypesToAdd)
+            {
+                if (symbol.Underlying?.SecurityType == SecurityType.Future)
+                {
+                    AddFutureOption(symbol.Underlying, BrokerageAlgorithmSettings.FutureOptionFilter);
+                    continue;
+                }
+
+                var security = AddSecurity(symbol, BrokerageAlgorithmSettings.Resolution);
+                dynamic filter;
+                switch (symbol.SecurityType)
+                {
+                    case SecurityType.Option:
+                        filter = BrokerageAlgorithmSettings.OptionFilter;
+                        break;
+                    case SecurityType.Future:
+                        filter = BrokerageAlgorithmSettings.FutureFilter;
+                        break;
+                    case SecurityType.IndexOption:
+                        filter = BrokerageAlgorithmSettings.IndexOptionFilter;
+                        break;
+                    case SecurityType.FutureOption:
+                        filter = BrokerageAlgorithmSettings.FutureOptionFilter;
+                        break;
+                    default:
+                        filter = null;
+                        break;
+                }
+
+                if (filter != null)
+                {
+                    switch (symbol.SecurityType)
+                    {
+                        case SecurityType.Option:
+                            (security as Option).SetFilter(filter);
+                            break;
+                        case SecurityType.Future:
+                            (security as Future).SetFilter(filter);
+                            break;
+                        case SecurityType.FutureOption:
+                            (security as FutureOption).SetFilter(filter);
+                            break;
+                        case SecurityType.IndexOption:
+                            (security as IndexOption).SetFilter(filter);
+                            break;
+                    }
+                }
+            }
+        }
+
+        protected virtual void SetupSymbols()
+        {
+            BrokerageAlgorithmSettings.InitializeSymbols();
+            _orderTypes = _orderTypeMethods.Keys.ToList();
+            _pointsFoundPerSymbol = BrokerageAlgorithmSettings.SecurityTypes.ToDictionary(x => x, x => 0);
+            _symbolsHaveBeenSetup = true;
+        }
+
+        public override void OnData(Slice slice)
+        {
+            if (!SetFutureContract(slice))
+            {
+                Debug($"{Time}: Waiting for future contract to be set...");
+                return;
+            }
+
+            if (!SetOptionContract(BrokerageAlgorithmSettings.CanonicalOptionSymbol, slice.OptionChains.Values, SecurityType.Option, ref BrokerageAlgorithmSettings.OptionContract))
+            {
+                Debug($"{Time}: Waiting for option contract to be set...");
+                return;
+            }
+
+            if (!SetOptionContract(BrokerageAlgorithmSettings.CanonicalIndexOptionSymbol, slice.OptionChains.Values, SecurityType.IndexOption, ref BrokerageAlgorithmSettings.IndexOptionContract))
+            {
+                Debug($"{Time}: Waiting for index option contract to be set...");
+                return;
+            }
+
+            if (!SetOptionContract(BrokerageAlgorithmSettings.CanonicalFutureOptionSymbol, slice.OptionChains.Values, SecurityType.FutureOption, ref BrokerageAlgorithmSettings.FutureOptionContract))
+            {
+                Debug($"{Time}: Waiting for future option contract to be set...");
+                return;
+            }
+
+            if (!_symbolsHaveBeenSetup)
+            {
+                SetupSymbols();
+            }
+
+            foreach (var symbol in BrokerageAlgorithmSettings.SecurityTypes)
+            {
+                if (!symbol.IsCanonical() && Securities[symbol].Price == 0)
+                {
+                    Debug($"{Time}: Waiting for {symbol} to have price...");
+                    return;
+                }
+            }
+
+            foreach(var symbol in slice.Keys)
+            {
+                if (BrokerageAlgorithmSettings.SecurityTypes.Contains(symbol))
+                {
+                    _pointsFoundPerSymbol[symbol]++;
+                }
+            }
+
+            if (Portfolio.Invested)
+            {
+                Debug($"{Time}: Liquidating so we start from scratch");
+                Liquidate();
+                return;
+            }
+
+            if (Transactions.GetOpenOrders().Count > 0)
+            {
+                Debug($"{Time}: Cancelling open orders so we start from scratch");
+                Transactions.CancelOpenOrders();
+                return;
+            }
+
+            var testCase = _orderTypes[_testCaseIndex];
+            var result = _orderTypeMethods[testCase](slice);
+
+            if (result != null && result.Any(x => x.Status == OrderStatus.Invalid) && (BrokerageAlgorithmSettings.SymbolToTestPerOrderType.ContainsKey(testCase)))
+            {
+                throw new RegressionTestException($"Brokerage was supposed to accept orders of type {testCase} but one order was invalid: " +
+                    $"{string.Join(", ", result.Where(x => x.Status == OrderStatus.Invalid))}");
+            }
+
+            _testCaseIndex++;
+            if (_testCaseIndex == _orderTypes.Count)
+            {
+                AssertHistory();
+                Quit();
+            }
+        }
+
+        public override void OnEndOfAlgorithm()
+        {
+            foreach(var symbol in _pointsFoundPerSymbol.Where(x => x.Value == 0).Select(x => x.Key))
+            {
+                throw new RegressionTestException($"No data was found for {symbol} symbol");
+            }
+        }
+
+        protected virtual void AssertHistory()
+        {
+            IEnumerable<IBaseData> history = default;
+            foreach (var symbol in BrokerageAlgorithmSettings.SecurityTypes)
+            {
+                foreach(var resolution in BrokerageAlgorithmSettings.ResolutionsPerSecurity[symbol.SecurityType])
+                {
+                    foreach(var type in BrokerageAlgorithmSettings.DataTypesPerSecurity[symbol.SecurityType])
+                    {
+                        Debug($"{type.Name} history request for {symbol.SecurityType} symbol {symbol} at {resolution} resolution ");
+                        if (type == typeof(QuoteBar))
+                        {
+                            history = History<QuoteBar>(symbol, 50, resolution).ToList();
+                        }
+                        else if (type == typeof(TradeBar))
+                        {
+                            history = History<TradeBar>(symbol, 50, resolution).ToList();
+                        }
+
+                        if (history.Count() != 50)
+                        {
+                            throw new Exception($"50 {type.Name}'s were expected for {symbol.SecurityType} symbol {symbol} at {resolution} resolution, but just obtained {history.Count()}");
+                        }
+                    }
+                }
+            }
+        }
+
+        protected virtual decimal GetOrderPrice(Symbol symbol, bool aboveTheMarket)
+        {
+            var assetPrice = Securities[symbol].Price;
+
+            if (aboveTheMarket)
+            {
+                if (symbol.SecurityType.IsOption() && assetPrice >= 2.95m)
+                {
+                    return (assetPrice + 0.05m).DiscretelyRoundBy(0.05m);
+                }
+                assetPrice = assetPrice + Math.Min(assetPrice * 0.001m, 0.25m);
+            }
+            else
+            {
+                if (symbol.SecurityType.IsOption() && assetPrice >= 2.95m)
+                {
+                    return (assetPrice - 0.05m).DiscretelyRoundBy(0.05m);
+                }
+                assetPrice = assetPrice - Math.Min(assetPrice * 0.001m, 0.25m);
+            }
+            return assetPrice;
+        }
+
+        protected virtual bool SetOptionContract(Symbol canonical, ICollection<OptionChain> chains, SecurityType securityType, ref Symbol contract)
+        {
+            if (canonical == null)
+            {
+                return true;
+            }
+
+            if (contract  == null)
+            {
+                foreach(var chain in chains)
+                {
+                    var atmContract = chain
+                        .Where(x => x.Symbol.SecurityType == securityType)
+                        .OrderByDescending(x => x.Expiry)
+                        .ThenBy(x => Math.Abs(chain.Underlying.Price - x.Strike))
+                        .ThenByDescending(x => x.Right)
+                        .FirstOrDefault();
+
+                    if (atmContract != null)
+                    {
+                        contract = atmContract.Symbol;
+                        break;
+                    }
+                }
+            }
+
+            return contract != null;
+        }
+
+        protected virtual bool SetFutureContract(Slice slice)
+        {
+            if (BrokerageAlgorithmSettings.CanonicalFutureSymbol == null)
+            {
+                return true;
+            }
+
+            if (BrokerageAlgorithmSettings.FutureContract == null)
+            {
+                foreach (var chain in slice.FutureChains.Values)
+                {
+                    var contract = (from futuresContract in chain.OrderBy(x => x.Expiry)
+                                    where futuresContract.Expiry > Time.Date.AddDays(29)
+                                    select futuresContract
+                    ).FirstOrDefault();
+                    if (contract != null)
+                    {
+                        BrokerageAlgorithmSettings.FutureContract = contract.Symbol;
+                        break;
+                    }
+                }
+            }
+            return BrokerageAlgorithmSettings.FutureContract != null;
+        }
+
+        protected virtual List<OrderTicket> ExecuteOrder(OrderType orderType)
+        {
+            if (!BrokerageAlgorithmSettings.SymbolToTestPerOrderType.TryGetValue(orderType, out var symbols))
+            {
+                symbols = BrokerageAlgorithmSettings.SecurityTypes; ;
+            }
+
+            Debug($"{Time}: Sending {orderType} orders");
+            var result = new List<OrderTicket>();
+            foreach (var symbol in symbols)
+            {
+                OrderTicket orderTicket = default;
+                decimal aboveTheMarket;
+                switch (orderType)
+                {
+                    case OrderType.Market:
+                        orderTicket = MarketOrder(symbol, GetOrderQuantity(symbol));
+                        break;
+                    case OrderType.Limit:
+                        orderTicket = LimitOrder(symbol, -GetOrderQuantity(symbol), GetOrderPrice(symbol, aboveTheMarket: false));
+                        break;
+                    case OrderType.StopMarket:
+                        orderTicket = StopMarketOrder(symbol, GetOrderQuantity(symbol), GetOrderPrice(symbol, aboveTheMarket: true));
+                        break;
+                    case OrderType.StopLimit:
+                        aboveTheMarket = GetOrderPrice(symbol, aboveTheMarket: false);
+                        orderTicket = StopLimitOrder(symbol, -GetOrderQuantity(symbol), aboveTheMarket, aboveTheMarket);
+                        break;
+                    case OrderType.LimitIfTouched:
+                        aboveTheMarket = GetOrderPrice(symbol, aboveTheMarket: false);
+                        orderTicket = LimitIfTouchedOrder(symbol, GetOrderQuantity(symbol), GetOrderPrice(symbol, aboveTheMarket: false), aboveTheMarket);
+                        break;
+                    case OrderType.TrailingStop:
+                        orderTicket = TrailingStopOrder(symbol, (int)GetOrderQuantity(symbol), 0.1m, true);
+                        break;
+                }
+                result.Add(orderTicket);
+            }
+
+            return result;
+        }
+
+        protected virtual List<OrderTicket> ExecuteMarketOnOpenOrders()
+        {
+            var result = new List<OrderTicket>();
+            if (Time.Date != _last.Date) // each morning submit a market on open order
+            {
+                Debug($"{Time}: Sending MarketOnOpen orders");
+                
+                if (!BrokerageAlgorithmSettings.SymbolToTestPerOrderType.TryGetValue(OrderType.MarketOnOpen, out var symbols))
+                {
+                    symbols = BrokerageAlgorithmSettings.SecurityTypes; ;
+                }
+                foreach (var symbol in symbols)
+                {
+                    if (!Securities[symbol].Exchange.Hours.IsMarketAlwaysOpen)
+                    {
+                        result.Add(MarketOnOpenOrder(symbol, GetOrderQuantity(symbol)));
+                    }
+                }
+
+                _submittedMarketOnCloseToday = false;
+                _last = Time;
+            }
+
+            return result;
+        }
+
+        protected virtual List<OrderTicket> ExecuteMarketOnCloseOrders()
+        {
+            var result = new List<OrderTicket>();
+            if (!_submittedMarketOnCloseToday) // once the exchange opens submit a market on close order
+            {
+                _submittedMarketOnCloseToday = true;
+                _last = Time;
+                Debug($"{Time}: Sending MarketOnClose orders");
+                if (!BrokerageAlgorithmSettings.SymbolToTestPerOrderType.TryGetValue(OrderType.MarketOnClose, out var symbols))
+                {
+                    symbols = BrokerageAlgorithmSettings.SecurityTypes; ;
+                }
+
+                foreach (var symbol in symbols)
+                {
+                    if (Securities[symbol].Exchange.ExchangeOpen && !Securities[symbol].Exchange.Hours.IsMarketAlwaysOpen)
+                    {
+                        result.Add(MarketOnCloseOrder(symbol, GetOrderQuantity(symbol)));
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        protected virtual List<OrderTicket> ExecuteOptionExerciseOrder()
+        {
+            if (BrokerageAlgorithmSettings.OptionContract == null)
+            {
+                return null;
+            }
+
+            MarketOrder(BrokerageAlgorithmSettings.OptionContract, 1);
+
+            // Exercise option
+            Debug($"{Time}: Exercising option contract");
+            var result = new List<OrderTicket>();
+            result.Add(ExerciseOption(BrokerageAlgorithmSettings.OptionContract, (int)GetOrderQuantity(BrokerageAlgorithmSettings.OptionContract)));
+            return result;
+        }
+
+        protected virtual List<OrderTicket> ExecuteComboOrder(Slice slice, OrderType orderType)
+        {
+            if (BrokerageAlgorithmSettings.OptionContract == null)
+            {
+                return null;
+            }
+
+            OptionChain chain;
+            if (IsMarketOpen(BrokerageAlgorithmSettings.OptionContract) && slice.OptionChains.TryGetValue(BrokerageAlgorithmSettings.CanonicalOptionSymbol, out chain))
+            {
+                var callContracts = chain.Where(contract => contract.Right == OptionRight.Call)
+                    .GroupBy(x => x.Expiry)
+                    .OrderBy(grouping => grouping.Key)
+                    .First()
+                    .OrderBy(x => x.Strike)
+                    .ToList();
+
+                // Let's wait until we have at least three contracts
+                if (callContracts.Count < 2)
+                {
+                    return null;
+                }
+
+                Debug($"{Time}: Sending combo market orders");
+                var orderLegs = new List<Leg>()
+                    {
+                        Leg.Create(callContracts[0].Symbol, (int)GetOrderQuantity(callContracts[0].Symbol)),
+                        Leg.Create(callContracts[1].Symbol, -(int)GetOrderQuantity(callContracts[1].Symbol)),
+                    };
+                switch (orderType)
+                {
+                    case OrderType.ComboMarket:
+                        return ComboMarketOrder(orderLegs, 2);
+                    case OrderType.ComboLimit:
+                        return ComboLimitOrder(orderLegs, 2, GetOrderPrice(callContracts[0].Symbol, false));
+                    case OrderType.ComboLegLimit:
+                        orderLegs = new List<Leg>()
+                        {
+                            Leg.Create(callContracts[0].Symbol, (int)GetOrderQuantity(callContracts[0].Symbol), GetOrderPrice(callContracts[0].Symbol, aboveTheMarket: false)),
+                            Leg.Create(callContracts[1].Symbol, -(int)GetOrderQuantity(callContracts[1].Symbol), GetOrderPrice(callContracts[1].Symbol, aboveTheMarket: false)),
+                        };
+                        return ComboLegLimitOrder(orderLegs, 2);
+                }
+            }
+
+            return null;
+        }
+
+        protected virtual decimal GetOrderQuantity(Symbol symbol)
+        {
+            return Securities[symbol].SymbolProperties.MinimumOrderSize ?? 1;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
I created a generic regression algorithm to assert the order types, security types, resolutions and data types of a given brokerage. In order to test a given brokerage we just need to create a new algorithm that inherits from the template and overrides the `BrokerageSettingsURL` and the `BrokerageName`.
#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #21 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this algorithm, will be able to test faster the properties of a given brokerage, this is, allowed order types, resolutions, data types and security types
#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->
N/A
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I used this template to test two different brokerages, Bybit and Interactive Brokers. I created a new algorithm for both of them, that inherited from the template but overrode the `BrokerageSettingsURL` as well as the `BrokerageName` property. None of the algorithms threw an exception and at the end of them, the statistics confirmed that orders have been submitted.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
